### PR TITLE
Bump Go version and refresh docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SHELL := /usr/bin/env bash
 SERVICE               = aws-apigateway-exporter
 BUILD_DIR             = bin
 PACKAGES              = $(shell go list -mod=vendor ./...)
-LINUX_BINARIES        = $(shell go list -mod=vendor ./... | grep -v -e vendor | awk -F/ '{print "bin/linux_amd64/" $$NF}')
-DARWIN_BINARIES       = $(shell go list -mod=vendor ./... | grep -v -e vendor |awk -F/ '{print "bin/darwin_amd64/" $$NF}')
+LINUX_BINARIES        = $(shell go list -mod=vendor ./... | grep -v -e vendor | awk -F/ '{print "$(BUILD_DIR)/linux_amd64/" $$NF}')
+DARWIN_BINARIES       = $(shell go list -mod=vendor ./... | grep -v -e vendor |awk -F/ '{print "$(BUILD_DIR)/darwin_amd64/" $$NF}')
 LINT_TARGETS          = $(shell go list -mod=vendor -f '{{.Dir}}' ./... | sed -e"s|${CURDIR}/\(.*\)\$$|\1/...|g" | grep -v ^node_modules/ )
 SYSTEM                = $(shell uname -s | tr A-Z a-z)_$(shell uname -m | sed "s/x86_64/amd64/")
 DEPENDENCIES          = $(shell find ./vendor -type f)
@@ -18,10 +18,12 @@ BUILD_TIME            = $(shell date +%FT%T%z)
 export GO111MODULE    = on
 
 $(BUILD_DIR)/linux_amd64/%: %/*.go $(DEPENDENCIES)
-	env GOOS=linux $(GO) build -ldflags="-s -w -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME)" -o $@ ./$(notdir $@)
+	mkdir -p $(dir $@)
+	env GOOS=linux GOARCH=amd64 $(GO) build -ldflags="-s -w -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME)" -o $@ ./$(notdir $@)
 
 $(BUILD_DIR)/darwin_amd64/%: %/*.go $(DEPENDENCIES)
-	env GOOS=darwin $(GO) build -ldflags="-s -w -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME)" -o $@ ./$(notdir $@)
+	mkdir -p $(dir $@)
+	env GOOS=darwin GOARCH=amd64 $(GO) build -ldflags="-s -w -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME)" -o $@ ./$(notdir $@)
 
 .PHONY: build
 build: $(LINUX_BINARIES) $(DARWIN_BINARIES)

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Replace `eu-central-1` in the policy when running the exporter with another `--r
 Make sure your machine has Go 1.26 installed, then run `make build-linux` to build the Linux binary. To build
 both Linux and Darwin amd64 binaries, run `make build`. To build the container image, run `make docker-build`.
 You can also use the provided container images:
-https://gallery.ecr.aws/s6w2n1r6/aws-apigateway-exporter
+https://gallery.ecr.aws/moia-oss/aws-apigateway-exporter
 
 For running the latest provided image:
-`docker run -p 9389:9389 public.ecr.aws/s6w2n1r6/aws-apigateway-exporter:latest`
+`docker run -p 9389:9389 public.ecr.aws/moia-oss/aws-apigateway-exporter:latest`
 
 For running a local image built by `make docker-build`:
 `docker run -p 9389:9389 moia/aws-apigateway-exporter:$(git describe --always --tags)`.
@@ -54,7 +54,7 @@ Every commit on `main` gets pushed as a new image with the `latest` tag.
 
 We recommend to use tagged versions in production.
 
-You can find the available tags on [AWS ECR Public Gallery](https://gallery.ecr.aws/s6w2n1r6/aws-apigateway-exporter).
+You can find the available tags on [AWS ECR Public Gallery](https://gallery.ecr.aws/moia-oss/aws-apigateway-exporter).
 
 ### Pushing a versioned image
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 Prometheus Exporter for details of AWS API Gateway metrics that are not available through CloudWatch but are
 available via the API. Currently, implemented are metrics about the client certificates and usage plans, especially
-the `created_date` and `expiry_date` of each certificate.
+the `created_date` and `expiration_date` of each certificate.
 
-The following metrics are then made available with the prefix `aws_apigateway_exporter_`.
-All metrics are gauge values:
+The exporter exposes the following gauge metrics. Metrics collected from AWS include a constant `region` label:
 
-* `expiration_date` with dimensions `client_certificate_id` and `api_gateway_name`
-* `created_date` with dimensions `client_certificate_id` and `api_gateway_name`
-* `used_quota` with dimensions `usage_plan_id`, `usage_plan_name`, and `usage_key_id`
-* `remaining_quota` with dimensions `usage_plan_id`, `usage_plan_name`, and `usage_key_id`
-* `quota_limit` with dimensions `usage_plan_id`, and `usage_plan_name`
+* `aws_apigateway_exporter_expiration_date` with labels `client_certificate_id`, `api_gateway_name`, and `region`
+* `aws_apigateway_exporter_created_date` with labels `client_certificate_id`, `api_gateway_name`, and `region`
+* `aws_apigateway_exporter_used_quota` with labels `usage_plan_id`, `usage_plan_name`, `usage_key_id`, and `region`
+* `aws_apigateway_exporter_remaining_quota` with labels `usage_plan_id`, `usage_plan_name`, `usage_key_id`, and `region`
+* `aws_apigateway_exporter_quota_limit` with labels `usage_plan_id`, `usage_plan_name`, and `region`
+* `aws_apigateway_exporter_up`
 
 ## Building and running
 
@@ -28,17 +28,22 @@ Resource:
   - "arn:aws:apigateway:eu-central-1::/usageplans*"
 ```
 
-Make sure your machine has Go 1.15 installed, then run `make docker-build` to build the service as well 
-as the docker image. You can also just use the provided docker images:
-https://gallery.ecr.aws/moia-oss/aws-apigateway-exporter
+Replace `eu-central-1` in the policy when running the exporter with another `--region`.
+
+Make sure your machine has Go 1.26 installed, then run `make build-linux` to build the Linux binary. To build
+both Linux and Darwin amd64 binaries, run `make build`. To build the container image, run `make docker-build`.
+You can also use the provided container images:
+https://gallery.ecr.aws/s6w2n1r6/aws-apigateway-exporter
 
 For running the latest provided image:
-`docker run -p 9389:9389 public.ecr.aws/moia-oss/aws-apigateway-exporter:latest`
+`docker run -p 9389:9389 public.ecr.aws/s6w2n1r6/aws-apigateway-exporter:latest`
 
-For running a local image:
-`docker run -p 9389:9389 moia/aws-apigateway-exporter`.
+For running a local image built by `make docker-build`:
+`docker run -p 9389:9389 moia/aws-apigateway-exporter:$(git describe --always --tags)`.
 
 Then Prometheus can scrape port 9389 for these metrics.
+
+The exporter defaults to `--listen-address=:9389` and `--region=eu-central-1`.
 
 ## Versioning on Public ECR
 
@@ -49,7 +54,7 @@ Every commit on `main` gets pushed as a new image with the `latest` tag.
 
 We recommend to use tagged versions in production.
 
-You can find the available tags on [AWS ECR Public Gallery](https://gallery.ecr.aws/moia-oss/aws-apigateway-exporter).
+You can find the available tags on [AWS ECR Public Gallery](https://gallery.ecr.aws/s6w2n1r6/aws-apigateway-exporter).
 
 ### Pushing a versioned image
 

--- a/aws-apigateway-exporter/main.go
+++ b/aws-apigateway-exporter/main.go
@@ -40,9 +40,9 @@ const (
 )
 
 var (
-	// BuildTime represents the time of the build
+	// BuildTime represents the time of the build.
 	BuildTime = "N/A"
-	// Version represents the Build SHA-1 of the binary
+	// Version represents the Build SHA-1 of the binary.
 	Version = "N/A"
 
 	logger *zap.Logger
@@ -60,7 +60,7 @@ type Exporter struct {
 	quotaLimit     *prometheus.Desc
 }
 
-// Describe implements prometheus.Collector interface
+// Describe implements prometheus.Collector interface.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.expirationDate
 	ch <- e.createdDate
@@ -70,7 +70,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.quotaLimit
 }
 
-// Collect implements prometheus.Collector interface
+// Collect implements prometheus.Collector interface.
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	up := 1 // indicates any error while scraping
 
@@ -81,7 +81,6 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	err = e.collectCertificateMetrics(&up, ch)
-
 	if err != nil {
 		up = 0
 		sugar.Errorf("Failed to get api gateways %s", err)
@@ -96,14 +95,22 @@ func (e *Exporter) collectCertificateMetrics(up *int, ch chan<- prometheus.Metri
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return err
+			return fmt.Errorf("get API Gateway REST APIs: %w", err)
 		}
 
 		for _, restAPI := range page.Items {
-			stagesResponse, stageErr := e.apigateway.GetStages(ctx, &apigateway.GetStagesInput{RestApiId: restAPI.Id})
+			apiID := aws.ToString(restAPI.Id)
+			if apiID == "" {
+				*up = 0
+				sugar.Warn("Skipping API Gateway without an ID")
+				continue
+			}
+			apiName := aws.ToString(restAPI.Name)
+
+			stagesResponse, stageErr := e.apigateway.GetStages(ctx, &apigateway.GetStagesInput{RestApiId: aws.String(apiID)})
 			if stageErr != nil {
 				*up = 0
-				sugar.Errorf("Failed to get stages for API Gateway %s: %s", *restAPI.Id, stageErr)
+				sugar.Errorf("Failed to get stages for API Gateway %s: %s", apiID, stageErr)
 				continue
 			}
 
@@ -112,11 +119,17 @@ func (e *Exporter) collectCertificateMetrics(up *int, ch chan<- prometheus.Metri
 					cert, err := e.apigateway.GetClientCertificate(ctx, &apigateway.GetClientCertificateInput{ClientCertificateId: stage.ClientCertificateId})
 					if err != nil {
 						*up = 0
-						sugar.Errorf("Failed to get client certificates %s for API Gateway %s: %s", *stage.ClientCertificateId, *restAPI.Id, err)
+						sugar.Errorf("Failed to get client certificates %s for API Gateway %s: %s", *stage.ClientCertificateId, apiID, err)
 						continue
 					}
-					ch <- prometheus.MustNewConstMetric(e.expirationDate, prometheus.GaugeValue, float64(cert.ExpirationDate.Unix()), *cert.ClientCertificateId, *restAPI.Name)
-					ch <- prometheus.MustNewConstMetric(e.createdDate, prometheus.GaugeValue, float64(cert.CreatedDate.Unix()), *cert.ClientCertificateId, *restAPI.Name)
+					certID := aws.ToString(cert.ClientCertificateId)
+					if certID == "" || cert.ExpirationDate == nil || cert.CreatedDate == nil {
+						*up = 0
+						sugar.Warnf("Skipping incomplete client certificate %s for API Gateway %s", aws.ToString(stage.ClientCertificateId), apiID)
+						continue
+					}
+					ch <- prometheus.MustNewConstMetric(e.expirationDate, prometheus.GaugeValue, float64(cert.ExpirationDate.Unix()), certID, apiName)
+					ch <- prometheus.MustNewConstMetric(e.createdDate, prometheus.GaugeValue, float64(cert.CreatedDate.Unix()), certID, apiName)
 				}
 			}
 		}
@@ -132,39 +145,50 @@ func (e *Exporter) collectUsageMetrics(up *int, ch chan<- prometheus.Metric) err
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return err
+			return fmt.Errorf("get API Gateway usage plans: %w", err)
 		}
 
 		for _, plan := range page.Items {
+			planID := aws.ToString(plan.Id)
+			if planID == "" {
+				*up = 0
+				sugar.Warn("Skipping usage plan without an ID")
+				continue
+			}
+			planName := aws.ToString(plan.Name)
 			today := time.Now().Format("2006-01-02")
 			usage, usageErr := e.apigateway.GetUsage(ctx, &apigateway.GetUsageInput{
 				EndDate:     &today,
 				StartDate:   &today,
-				UsagePlanId: plan.Id,
+				UsagePlanId: aws.String(planID),
 			})
 			if usageErr != nil {
 				*up = 0
-				sugar.Errorf("Failed to get usage data for API Usage Plan %s (%s): %s", *plan.Id, *plan.Name, usageErr)
+				sugar.Errorf("Failed to get usage data for API Usage Plan %s (%s): %s", planID, planName, usageErr)
 				continue
 			}
 
 			for key, val := range usage.Items {
+				used, remaining, ok := usageValuesForToday(val)
+				if !ok {
+					*up = 0
+					sugar.Warnf("Skipping unexpected usage data for API Usage Plan %s (%s) and usage key %s", planID, planName, key)
+					continue
+				}
 				ch <- prometheus.MustNewConstMetric(
 					e.usedQuota,
 					prometheus.GaugeValue,
-					// note that we always get the first element of val because we only ask for one day of data
-					float64(val[0][0]),
-					*plan.Id,
-					*plan.Name,
+					float64(used),
+					planID,
+					planName,
 					key,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					e.remainingQuota,
 					prometheus.GaugeValue,
-					// note that we always get the first element of val because we only ask for one day of data
-					float64(val[0][1]),
-					*plan.Id,
-					*plan.Name,
+					float64(remaining),
+					planID,
+					planName,
 					key,
 				)
 			}
@@ -174,14 +198,21 @@ func (e *Exporter) collectUsageMetrics(up *int, ch chan<- prometheus.Metric) err
 					e.quotaLimit,
 					prometheus.GaugeValue,
 					float64(plan.Quota.Limit),
-					*plan.Id,
-					*plan.Name,
+					planID,
+					planName,
 				)
 			}
 		}
 	}
 
 	return nil
+}
+
+func usageValuesForToday(values [][]int64) (used, remaining int64, ok bool) {
+	if len(values) == 0 || len(values[0]) < 2 {
+		return 0, 0, false
+	}
+	return values[0][0], values[0][1], true
 }
 
 func registerSignals() {
@@ -245,7 +276,12 @@ func main() {
 		}
 	})
 	sugar.Info("Listening on", *listenAddr)
-	if err := http.ListenAndServe(*listenAddr, mux); err != nil {
+	server := &http.Server{
+		Addr:              *listenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
 		sugar.Errorf("Error on serving the requests %s", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/moia-dev/aws-apigateway-exporter
+module github.com/moia-oss/aws-apigateway-exporter
 
-go 1.25
+go 1.26
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7

--- a/mk-templates/assets/golangci.yml
+++ b/mk-templates/assets/golangci.yml
@@ -1,25 +1,18 @@
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  # use the fixed version to not introduce new linters unexpectedly
-  golangci-lint-version: 1.54.x
+version: "2"
 
 run:
-  # golang-ci lint runtime timeout
-  deadline: 5m
-  # moias latest supported Go version
-  go: "1.22"
-  # see: https://golangci-lint.run/usage/configuration/
-  modules-download-mode: readonly
+  # golangci-lint runtime timeout
+  timeout: 5m
+  go: "1.26"
+  # see: https://golangci-lint.run/docs/configuration/file/
+  modules-download-mode: vendor
   # include test files or not.
   tests: false
 
 linters:
   # Enable specific linter (not part of default linters)
-  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  # https://golangci-lint.run/docs/linters/
   enable:
-    # gofumpt as replacement for gofmt.
-    - gofumpt
     # revive as replacement for golint.
     - revive
     # whitespace to identify unnecessary whitespaces.
@@ -34,38 +27,37 @@ linters:
     - wrapcheck
     # misspell checks for spelling mistakes
     - misspell
-
-issues:
-  # independently of option `exclude` we use default exclude patterns
-  exclude-use-default: false
   # excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test.go
-      linters:
-        - errcheck
-
-linters-settings:
-  # gofumpt settings
-  gofumpt:
-    extra-rules: true
-  # misspell settings
-  misspell:
-    locale: US
-  # revive settings
-  revive:
-    ignore-generated-header: true
-    severity: warning
+  exclusions:
+    generated: strict
     rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
-      - name: unexported-return
-        severity: warning
-        disabled: true
-  # gosec settings
-  gosec:
-    excludes:
-      # exclude random number check
-      - G404
-      # allowance of net/http serve function that has no support for setting timeouts
-      - G114
-  gocyclo:
-    min-complexity: 15
+      - path: _test.go
+        linters:
+          - errcheck
+  settings:
+    # misspell settings
+    misspell:
+      locale: US
+    # revive settings
+    revive:
+      severity: warning
+      rules:
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
+        - name: unexported-return
+          severity: warning
+          disabled: true
+    # gosec settings
+    gosec:
+      excludes:
+        # exclude random number check
+        - G404
+    gocyclo:
+      min-complexity: 15
+
+formatters:
+  enable:
+    # gofumpt as replacement for gofmt.
+    - gofumpt
+  settings:
+    gofumpt:
+      extra-rules: true

--- a/mk-templates/go.mk
+++ b/mk-templates/go.mk
@@ -1,4 +1,4 @@
-# This overrides the default go command withenv Variables which are usually
+# This overrides the default go command with env variables which are usually
 # used in moia-dev repositories
 SYSTEM                := $(shell uname -s | tr A-Z a-z)_$(shell uname -m | sed "s/x86_64/amd64/" | sed "s/aarch64/arm64/")
 GO_PREFIX             := CGO_ENABLED=0 GOFLAGS=-mod=vendor GOPRIVATE=github.com/moia-dev
@@ -13,7 +13,7 @@ LINT_TARGETS          := $(shell find . -name '*.go' | sed -e "s|\(.*\)/.*\.go\$
 endif
 # The current version of golangci-lint.
 # See: https://github.com/golangci/golangci-lint/releases
-GOLANGCI_LINT_VERSION ?= 2.7.2
+GOLANGCI_LINT_VERSION ?= 2.12.2
 
 # Executes the linter on all our go files inside of the project
 .PHONY: lint create-golint-config
@@ -22,7 +22,7 @@ lint: bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 .PHONY: create-golint-config
 create-golint-config:
-	cp -n moia-mk-templates/assets/golangci.yml .golangci.yml || true
+	cp -n mk-templates/assets/golangci.yml .golangci.yml || true
 
 # Downloads the current golangci-lint executable into the bin directory and
 # makes it executable


### PR DESCRIPTION
## Summary
- bump module Go version to 1.26 and align golangci-lint tooling
- refresh README details to match current metrics, build targets, and ECR image location
- harden exporter collection around incomplete AWS responses and add HTTP read-header timeout